### PR TITLE
Fix typo in example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ try {
 
     for (auto r: row_range(st)) {
         auto name = r[0].value<std::string_view>();
-        auto age = r[0].value<int>();
+        auto age = r[1].value<int>();
     }
 
     db->exec("SELECT name, age FROM mytable", [](int statement_idx, row r) noexcept {
         auto name = r[0].value<std::string_view>();
-        auto age = r[0].value<int>();
+        auto age = r[1].value<int>();
         return true;
     });
 


### PR DESCRIPTION
This PR fixes a typo in row access index in two places. Confused me momentarily while reading, so I figured it's worth making a PR for.